### PR TITLE
Change uid in passwd at runtime

### DIFF
--- a/nss_wrapper/dep1.yml
+++ b/nss_wrapper/dep1.yml
@@ -23,9 +23,3 @@ spec:
           args:
             - sed -i 's/185/1000710000/g' passwd && cat
           tty: true
-          volumeMounts:
-            - name: shared-data
-              mountPath: /tmp
-      volumes:
-        - name: shared-data
-          emptyDir: { }

--- a/nss_wrapper/dep1.yml
+++ b/nss_wrapper/dep1.yml
@@ -15,19 +15,13 @@ spec:
         app: my-app
     spec:
       securityContext:
-        runAsUser: 1000
+        runAsUser: 1000710000
       containers:
         - name: maven3
-          image: localhost:5000/snowdrop/ubi8-openjdk11-git
-          command:
-          - cat
-          env:
-           - name: LD_PRELOAD
-             value: libnss_wrapper.so
-           - name: NSS_WRAPPER_PASSWD
-             value: /home/jboss/passwd
-           - name: NSS_WRAPPER_GROUP
-             value: /etc/group
+          image: registry.access.redhat.com/ubi8/openjdk-11 #localhost:5000/snowdrop/ubi8-openjdk11-git
+          command: ['sh', '-c']
+          args:
+            - sed -i 's/185/1000710000/g' passwd && cat
           tty: true
           volumeMounts:
             - name: shared-data


### PR DESCRIPTION
The pull request does the following:

- sets `runAsUser` to an Openshift-friendly value
- uses sed to change uid from 185 to `runAsUser` value when pod starts.

Reasoning:

The ubi8-openjdk11 image already uses nss-wrapper in order to control the jboss user uid.
Unfortunately, this uid is not an acceptable uid for openshift which requires > 1000710000.
So, this PR modifies using sed, that fixed 185 uid for jboss, so that its aligned with what we already have for `runAsUser`